### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper-compat (= 13),
                python3-bs4,
                python3-setuptools,
                libxml2-dev,
-               python3-lxml (>= 3.8.0),
+               python3-lxml,
                pkg-config
 Standards-Version: 4.6.1
 Homepage: https://github.com/kovidgoyal/html5-parser


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/html5-parser/5c9e6750-b6bf-4ade-a502-48f0c0587d20.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files of package python3-html5-parser: lines which differ (wdiff format)
* Depends: python3 (<< 3.11), python3 (>= 3.9~), python3-chardet, [-python3-lxml (>= 3.8.0),-] {+python3-lxml,+} python3:any, libc6 (>= 2.14), libxml2 (>= 2.7.4)

No differences were encountered between the control files of package \*\*python3-html5-parser-dbgsym\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/5c9e6750-b6bf-4ade-a502-48f0c0587d20/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/5c9e6750-b6bf-4ade-a502-48f0c0587d20/diffoscope)).
